### PR TITLE
support linux deployments

### DIFF
--- a/.github/workflows/createrelease.yml
+++ b/.github/workflows/createrelease.yml
@@ -70,9 +70,34 @@ jobs:
         name: sharedconfig
         path: sharedconfig.zip
 
-  deploystaging:
-     if: "!github.event.release.prerelease"
-     runs-on: stagingserver
+  parse-deploy-body:
+    runs-on: ubuntu-latest
+    outputs:
+      deploy_linux: ${{ steps.set.outputs.deploy_linux }}
+      deploy_windows: ${{ steps.set.outputs.deploy_windows }}
+    steps:
+      - name: Parse deployment targets from release body
+        id: set
+        run: |
+          body="${{ github.event.release.body }}"
+          targets=$(echo "$body" | grep -i '^deploy:' | cut -d':' -f2 | tr -d ' ' | tr '[:upper:]' '[:lower:]')
+
+          if [[ "$targets" == *"linux"* ]]; then
+            echo "deploy_linux=true" >> $GITHUB_OUTPUT
+          else
+            echo "deploy_linux=false" >> $GITHUB_OUTPUT
+          fi
+
+          if [[ "$targets" == *"windows"* ]]; then
+            echo "deploy_windows=true" >> $GITHUB_OUTPUT
+          else
+            echo "deploy_windows=false" >> $GITHUB_OUTPUT
+          fi
+
+  deploystaging_windows:
+     needs: parse-deploy-body
+     if: needs.parse-deploy-body.outputs.deploy_linux == 'true'
+     runs-on: [stagingserver, windows]
      needs: buildconfigpackage
      environment: staging
      name: "Deploy to Staging"
@@ -87,10 +112,29 @@ jobs:
        run: |
           Expand-Archive -Path sharedconfig.zip -DestinationPath "C:\home\txnproc\config" -Force
 
-  deployproduction:
-     if: "!github.event.release.prerelease"
-     runs-on: productionserver
-     needs: [buildconfigpackage, deploystaging]
+  deploystaging_linux:
+     needs: parse-deploy-body
+     if: needs.parse-deploy-body.outputs.deploy_linux == 'true'
+     runs-on: [stagingserver, linux]
+     needs: buildconfigpackage
+     environment: staging
+     name: "Deploy to Staging"
+
+     steps:
+     - name: Download the artifact
+       uses: actions/download-artifact@v4.1.7
+       with:
+          name: sharedconfig
+          
+     - name: deploy config
+       run: |
+           unzip sharedconfig.zip -d /home/txnproc/config
+
+  deployproduction_windows:
+     needs: parse-deploy-body
+     if: needs.parse-deploy-body.outputs.deploy_linux == 'true'     
+     runs-on: [productionserver, windows]
+     needs: [buildconfigpackage, deploystaging_windows]
      environment: production
      name: "Deploy to Production"
     
@@ -103,3 +147,21 @@ jobs:
      - name: deploy config
        run: |
           Expand-Archive -Path sharedconfig.zip -DestinationPath "C:\home\txnproc\config" -Force
+
+  deployproduction_linux:
+     needs: parse-deploy-body
+     if: needs.parse-deploy-body.outputs.deploy_linux == 'true'     
+     runs-on: [productionserver, linux]
+     needs: [buildconfigpackage, deploystaging_linux]
+     environment: production
+     name: "Deploy to Production"
+    
+     steps:
+     - name: Download the artifact
+       uses: actions/download-artifact@v4.1.7
+       with:
+          name: sharedconfig
+          
+     - name: deploy config
+       run: |
+           unzip sharedconfig.zip -d /home/txnproc/config

--- a/config/appsettings.json
+++ b/config/appsettings.json
@@ -8,14 +8,13 @@
   },
   "AllowedHosts": "*",
   "AppSettings": {
-    "Authority": "https://192.168.1.167:5001",
+    "Authority": "https://192.168.1.163:5001",
     "ClientId": "", // This will be overridden in each service/application
     "ClientSecret": "", // This will be overridden in each service/application
-    "EstateManagementApi": "http://192.168.1.167:5000",
-    "FileProcessorApi": "http://192.168.1.167:5009",
-    "SecurityService": "https://192.168.1.167:5001",
-    "MessagingServiceApi": "http://192.168.1.167:5006",
-    "TransactionProcessorApi": "http://192.168.1.167:5002",
+    "FileProcessorApi": "http://192.168.1.163:5009",
+    "SecurityService": "https://192.168.1.163:5001",
+    "MessagingServiceApi": "http://192.168.1.163:5006",
+    "TransactionProcessorApi": "http://192.168.1.163:5002",
     "HandlerEventTypesToSilentlyHandle": {}, // This will be overridden in each service/application
     "UseConnectionStringConfig": false,
     "EventHandlerConfiguration": {}, // This will be overridden in each service/application
@@ -30,20 +29,20 @@
     "PDFGenerationBinariesPath": "home/txnproc/syncfusion/QtBinariesLinux"
   },
   "EventStoreSettings": {
-    "ConnectionString": "esdb://admin:changeit@192.168.1.167:2113?tls=false&tlsVerifyCert=false",
+    "ConnectionString": "esdb://admin:changeit@192.168.1.163:2113?tls=false&tlsVerifyCert=false",
     "UserName": "admin",
     "Password": "changeit"
   },
   "ConnectionStrings": {
-    "ConnectionStringConfiguration": "server=192.168.1.167;user id=sa;password=Sc0tland;database=ConnectionStringConfiguration;Encrypt=false",
-    "EstateReportingReadModel": "server=192.168.1.167;user id=sa;password=Sc0tland;database=EstateReportingReadModel;Encrypt=false",
-    "HealthCheck": "server=192.168.1.167;database=master;user id=sa;password=Sc0tland;Encrypt=false"
+    "ConnectionStringConfiguration": "server=192.168.1.163;user id=sa;password=Sc0tland;database=ConnectionStringConfiguration;Encrypt=false",
+    "EstateReportingReadModel": "server=192.168.1.163;user id=sa;password=Sc0tland;database=EstateReportingReadModel;Encrypt=false",
+    "HealthCheck": "server=192.168.1.163;database=master;user id=sa;password=Sc0tland;Encrypt=false"
   },
   "SecurityConfiguration": {
     "ApiName": "", // This will be overridden in each service/application
-    "Authority": "https://192.168.1.167:5001"
+    "Authority": "https://192.168.1.163:5001"
   },
   "ServiceAddresses": {
-    "MessagingService": "http://192.168.1.167:5006"
+    "MessagingService": "http://192.168.1.163:5006"
   }
 }

--- a/config/appsettings.staging.json
+++ b/config/appsettings.staging.json
@@ -8,33 +8,32 @@
   },
   "AllowedHosts": "*",
   "AppSettings": {
-    "Authority": "https://192.168.1.167:5001",
+    "Authority": "https://192.168.1.163:5001",
     "ClientId": "", // This will be overridden in each service/application
-    "ClientSecret": "", // This will be overridden in each service/application
-    "EstateManagementApi": "http://192.168.1.167:5000",
-    "FileProcessorApi": "http://192.168.1.167:5009",
-    "SecurityService": "https://192.168.1.167:5001",
-    "MessagingServiceApi": "http://192.168.1.167:5006",
-    "TransactionProcessorApi": "http://192.168.1.167:5002",
+    "ClientSecret": "", // This will be overridden in each service/application    
+    "FileProcessorApi": "http://192.168.1.163:5009",
+    "SecurityService": "https://192.168.1.163:5001",
+    "MessagingServiceApi": "http://192.168.1.163:5006",
+    "TransactionProcessorApi": "http://192.168.1.163:5002",
     "HandlerEventTypesToSilentlyHandle": {}, // This will be overridden in each service/application
     "UseConnectionStringConfig": false,
     "EventHandlerConfiguration": {} // This will be overridden in each service/application
   },
   "EventStoreSettings": {
-    "ConnectionString": "esdb://admin:changeit@192.168.1.167:2113?tls=false&tlsVerifyCert=false",
+    "ConnectionString": "esdb://admin:changeit@192.168.1.163:2113?tls=false&tlsVerifyCert=false",
     "UserName": "admin",
     "Password": "changeit"
   },
   "ConnectionStrings": {
-    "ConnectionStringConfiguration": "server=192.168.1.167;user id=sa;password=Sc0tland;database=ConnectionStringConfiguration;Encrypt=false",
-    "EstateReportingReadModel": "server=192.168.1.167;user id=sa;password=Sc0tland;database=EstateReportingReadModel;Encrypt=false",
-    "HealthCheck": "server=192.168.1.167;database=master;user id=sa;password=Sc0tland;Encrypt=false"
+    "ConnectionStringConfiguration": "server=192.168.1.163;user id=sa;password=Sc0tland;database=ConnectionStringConfiguration;Encrypt=false",
+    "EstateReportingReadModel": "server=192.168.1.163;user id=sa;password=Sc0tland;database=EstateReportingReadModel;Encrypt=false",
+    "HealthCheck": "server=192.168.1.163;database=master;user id=sa;password=Sc0tland;Encrypt=false"
   },
   "SecurityConfiguration": {
     "ApiName": "", // This will be overridden in each service/application
-    "Authority": "https://192.168.1.167:5001"
+    "Authority": "https://192.168.1.163:5001"
   },
   "ServiceAddresses": {
-    "MessagingService": "http://192.168.1.167:5006"
+    "MessagingService": "http://192.168.1.163:5006"
   }
 }


### PR DESCRIPTION
Refactor deployment jobs and update service URLs

Modified `createrelease.yml` to implement a new job structure for conditional deployments to Linux and Windows based on parsed targets. Split existing jobs into separate Linux and Windows jobs with appropriate steps for artifact handling.

Updated `appsettings.json` and `appsettings.staging.json` to change authority and API endpoint URLs from `192.168.1.167` to `192.168.1.163`, ensuring correct server references for production and staging environments.

closes #36 